### PR TITLE
use static header instead

### DIFF
--- a/src/components/layout/GoToTop.astro
+++ b/src/components/layout/GoToTop.astro
@@ -1,0 +1,33 @@
+---
+import { useTranslation, type Language } from "@/utils/i18n";
+
+interface Props {
+  lang: Language;
+}
+
+const t = useTranslation(Astro.props.lang);
+const label = t("ui", "go_top");
+---
+
+<a
+  id="gtt"
+  href="#header"
+  class="fixed bottom-4 right-4 z-40 inline-block rounded-md bg-blue-50 p-1 shadow-md transition-transform dark:bg-slate-700"
+>
+  <span class="sr-only">{label}</span>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+    <path
+      fill-rule="evenodd"
+      d="M12 20.25a.75.75 0 01-.75-.75V6.31l-5.47 5.47a.75.75 0 01-1.06-1.06l6.75-6.75a.75.75 0 011.06 0l6.75 6.75a.75.75 0 11-1.06 1.06l-5.47-5.47V19.5a.75.75 0 01-.75.75z"
+      clip-rule="evenodd"></path>
+  </svg>
+</a>
+<script>
+  const goTotop = document.getElementById("gtt") as HTMLLinkElement;
+  goTotop.classList.add("scale-0");
+  window.addEventListener("scroll", () => {
+    return window.scrollY > window.innerHeight
+      ? goTotop.classList.remove("scale-0")
+      : goTotop.classList.add("scale-0");
+  });
+</script>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -12,7 +12,7 @@ const lang = Astro.props.lang ?? DEFAULT_LOCALE;
 const t = useTranslation(lang);
 ---
 
-<header class="top-0 w-full bg-white shadow-md transition-transform dark:bg-slate-950">
+<header id="header" class="top-0 w-full bg-white shadow-md transition-transform dark:bg-slate-950">
   <div class="mx-auto max-w-7xl px-2 md:border-none md:px-6 lg:px-8">
     <div class="relative flex h-20 items-center justify-between">
       <div class="absolute inset-y-0 left-0 flex items-center md:hidden">

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -12,7 +12,7 @@ const lang = Astro.props.lang ?? DEFAULT_LOCALE;
 const t = useTranslation(lang);
 ---
 
-<header class="fixed top-0 z-40 w-full bg-white shadow-md transition-transform dark:bg-slate-950">
+<header class="top-0 w-full bg-white shadow-md transition-transform dark:bg-slate-950">
   <div class="mx-auto max-w-7xl px-2 md:border-none md:px-6 lg:px-8">
     <div class="relative flex h-20 items-center justify-between">
       <div class="absolute inset-y-0 left-0 flex items-center md:hidden">

--- a/src/components/layout/MinimalHeader.astro
+++ b/src/components/layout/MinimalHeader.astro
@@ -9,7 +9,7 @@ const lang = Astro.props.lang ?? DEFAULT_LOCALE;
 const t = useTranslation(lang);
 ---
 
-<header class="relative top-0 z-40 w-full bg-slate-50 shadow-md dark:bg-gray-900">
+<header id="header" class="relative top-0 w-full bg-slate-50 shadow-md dark:bg-gray-900">
   <div class="mx-auto max-w-7xl px-2 sm:border-none sm:px-6 lg:px-8">
     <div class="relative flex h-20 items-center justify-between">
       <a class="inline-block" href={getLocalizedPage(lang, "home")} title={t("navigation", "go_home")}>

--- a/src/components/layout/utils/mobile-menu.ts
+++ b/src/components/layout/utils/mobile-menu.ts
@@ -1,8 +1,4 @@
 import { showCommandBar } from "@/stores/command-bar.store";
-const ScrollDirection = {
-  UP: "UP",
-  DOWN: "DOWN",
-} as const;
 
 document.addEventListener("DOMContentLoaded", () => {
   /* eslint-disable @typescript-eslint/non-nullable-type-assertion-style */
@@ -20,33 +16,10 @@ document.addEventListener("DOMContentLoaded", () => {
     icon: menuIcon,
     text: buttonText,
   });
-  toggleHeaderOnScroll(header, toggleMobileMenu);
+  window.addEventListener("scroll", () => window.scrollY > 30 && toggleMobileMenu(true), { passive: true });
   menuButton.addEventListener("click", () => toggleMobileMenu());
   searchButton.addEventListener("click", showCommandBar);
 });
-
-function toggleHeaderOnScroll(header: HTMLElement, closeMobileMenu: (isOpen: boolean) => void, threshold = 100) {
-  let prevScrollpos = window.pageYOffset;
-  window.addEventListener(
-    "scroll",
-    () => {
-      const currentScrollPos = window.pageYOffset;
-      const scrollDirection = currentScrollPos > prevScrollpos ? ScrollDirection.DOWN : ScrollDirection.UP;
-      const isSignificantScroll = Math.abs(currentScrollPos - prevScrollpos) > threshold;
-
-      if (isSignificantScroll) {
-        prevScrollpos = currentScrollPos;
-        if (scrollDirection === ScrollDirection.DOWN) {
-          header.classList.add("-translate-y-full");
-          closeMobileMenu(true);
-        } else {
-          header.classList.remove("-translate-y-full");
-        }
-      }
-    },
-    { passive: true }
-  );
-}
 
 function setMobileMenu({
   button,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -45,7 +45,8 @@
     "theme.dark": "Dark",
     "theme.light": "Light",
     "theme.auto": "System",
-    "theme.select": "Select a theme"
+    "theme.select": "Select a theme",
+    "go_top": "Go to top"
   },
   "messages": {
     "page_not_found": "Page not found",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -45,7 +45,8 @@
     "theme.dark": "Oscuro",
     "theme.light": "Claro",
     "theme.auto": "Sistema",
-    "theme.select": "Cambiar tema"
+    "theme.select": "Cambiar tema",
+    "go_top": "Ir al principio"
   },
   "messages": {
     "page_not_found": "Página no encontrada",

--- a/src/layouts/Basic.astro
+++ b/src/layouts/Basic.astro
@@ -39,7 +39,7 @@ const { origin } = Astro.url;
     <link rel="alternate icon" type="image/x-icon" href="/favicon.ico?v=2" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />
     <meta name="theme-color" content="hsl(228, 84%, 5%)" media="(prefers-color-scheme: dark)" />
-    <meta name="theme-color" content="hsl(0, 0, 100%)" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="hsl(0, 0, 100%)" />
     <meta name="docsearch:language" content={lang} />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>

--- a/src/layouts/Basic.astro
+++ b/src/layouts/Basic.astro
@@ -31,7 +31,7 @@ const { origin } = Astro.url;
 ---
 
 <!DOCTYPE html>
-<html lang={lang} class:list={{ "h-screen": fullHeight }}>
+<html lang={lang} class:list={{ "h-screen": fullHeight }} class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />

--- a/src/layouts/Basic.astro
+++ b/src/layouts/Basic.astro
@@ -31,10 +31,10 @@ const { origin } = Astro.url;
 ---
 
 <!DOCTYPE html>
-<html lang={lang} class:list={{ "h-screen": fullHeight }} class="scroll-smooth">
+<html lang={lang} class:list={{ "h-screen": fullHeight }} class="overflow-x-hidden scroll-smooth">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />
     <link rel="alternate icon" type="image/x-icon" href="/favicon.ico?v=2" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />

--- a/src/layouts/WithHeader.astro
+++ b/src/layouts/WithHeader.astro
@@ -39,7 +39,5 @@ const {
     <slot name="head" />
   </Fragment>
   <Header lang={lang} />
-  <!-- This is a hack to prevent the header from overlapping the content -->
-  {!noHeaderSpacing && <div aria-hidden="true" class="h-20" />}
   <slot />
 </Basic>

--- a/src/layouts/WithHeader.astro
+++ b/src/layouts/WithHeader.astro
@@ -40,4 +40,24 @@ const {
   </Fragment>
   <Header lang={lang} />
   <slot />
+  <a
+    id="gtt"
+    href="#header"
+    class="fixed bottom-4 right-4 z-40 inline-block rounded-md bg-blue-50 p-3 shadow-md transition-transform dark:bg-slate-700"
+  >
+    <span class="sr-only">Go to top</span>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
+      <path
+        fill-rule="evenodd"
+        d="M12 20.25a.75.75 0 01-.75-.75V6.31l-5.47 5.47a.75.75 0 01-1.06-1.06l6.75-6.75a.75.75 0 011.06 0l6.75 6.75a.75.75 0 11-1.06 1.06l-5.47-5.47V19.5a.75.75 0 01-.75.75z"
+        clip-rule="evenodd"></path>
+    </svg>
+  </a>
+  <script>
+    const goTotop = document.getElementById("gtt") as HTMLLinkElement;
+    goTotop.classList.add("scale-0");
+    window.addEventListener("scroll", () => {
+      return window.scrollY > 100 ? goTotop.classList.remove("scale-0") : goTotop.classList.add("scale-0");
+    });
+  </script>
 </Basic>

--- a/src/layouts/WithHeader.astro
+++ b/src/layouts/WithHeader.astro
@@ -4,6 +4,7 @@ import Basic from "./Basic.astro";
 import Header from "@/components/layout/Header.astro";
 import { DEFAULT_LOCALE } from "@/utils/i18n";
 import type { DefaultLayoutProps } from "./types";
+import GoToTop from "@/components/layout/GoToTop.astro";
 
 interface Props extends DefaultLayoutProps {
   noHeaderSpacing?: boolean;
@@ -40,24 +41,5 @@ const {
   </Fragment>
   <Header lang={lang} />
   <slot />
-  <a
-    id="gtt"
-    href="#header"
-    class="fixed bottom-4 right-4 z-40 inline-block rounded-md bg-blue-50 p-3 shadow-md transition-transform dark:bg-slate-700"
-  >
-    <span class="sr-only">Go to top</span>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="h-6 w-6">
-      <path
-        fill-rule="evenodd"
-        d="M12 20.25a.75.75 0 01-.75-.75V6.31l-5.47 5.47a.75.75 0 01-1.06-1.06l6.75-6.75a.75.75 0 011.06 0l6.75 6.75a.75.75 0 11-1.06 1.06l-5.47-5.47V19.5a.75.75 0 01-.75.75z"
-        clip-rule="evenodd"></path>
-    </svg>
-  </a>
-  <script>
-    const goTotop = document.getElementById("gtt") as HTMLLinkElement;
-    goTotop.classList.add("scale-0");
-    window.addEventListener("scroll", () => {
-      return window.scrollY > 100 ? goTotop.classList.remove("scale-0") : goTotop.classList.add("scale-0");
-    });
-  </script>
+  <GoToTop lang={lang} />
 </Basic>

--- a/src/layouts/WithMiniHeader.astro
+++ b/src/layouts/WithMiniHeader.astro
@@ -4,6 +4,7 @@ import Basic from "./Basic.astro";
 import Header from "@/components/layout/MinimalHeader.astro";
 import { DEFAULT_LOCALE } from "@/utils/i18n";
 import type { DefaultLayoutProps } from "./types";
+import GoToTop from "@/components/layout/GoToTop.astro";
 
 type Props = DefaultLayoutProps;
 
@@ -37,4 +38,5 @@ const {
   </Fragment>
   <Header lang={lang} />
   <slot />
+  <GoToTop lang={lang} />
 </Basic>

--- a/src/pages/en/about.mdx
+++ b/src/pages/en/about.mdx
@@ -69,7 +69,7 @@ I build what the user sees when they visit the page. The buttons, colours and in
 
   Having a good developer experience is critical to having good developer productivity. And good developer productivity means more value to our users.
 
-  **Code quality**: I always try to write code that is easy to read and understand, avoiding unnecessary complexity and [hasty abstractions](https://kentcdodds.com/blog/aha-programming).
+  **Code quality**: I always try to write code that is easy to read and understand, avoiding unnecessary complexity and hasty abstractions.
 
   **Testing & Documentation**: Part of being productive is not wasting time figuring out how things work. Having the confidence that your changes won't break something else sometimes is underrated. Writting good docs and tests has saved future Misael a handful of times.
 


### PR DESCRIPTION
I've always loved the dynamic show/hide header since it was hard to implement (we didn't have `position: fixed` back then). But it is time to end that (personal) trend and use a static header with a Back to top button.

There was also a bug on the Spanish version of the contact page where the title was only partially visible due to this dynamic header.