### PR TITLE
feat: remove i18n impact on the final bundle

### DIFF
--- a/src/components/PostTranslations.astro
+++ b/src/components/PostTranslations.astro
@@ -10,7 +10,7 @@ interface Props {
 
 const { translations, class: className } = Astro.props;
 
-const t = useTranslation(Astro.props.lang);
+const t = await useTranslation(Astro.props.lang);
 ---
 
 <aside class="my-6 rounded-sm bg-blue-100 p-4 text-sm dark:bg-slate-900" class:list={className}>

--- a/src/components/TranslationArchiveBanner.astro
+++ b/src/components/TranslationArchiveBanner.astro
@@ -8,7 +8,7 @@ export interface Props {
   type: CollectionKey;
 }
 const { lang, type } = Astro.props;
-const t = useTranslation(lang);
+const t = await useTranslation(lang);
 ---
 
 {

--- a/src/components/command-bar/CommandBar.tsx
+++ b/src/components/command-bar/CommandBar.tsx
@@ -27,7 +27,6 @@ type CommandBarProps = {
 export default function CommandBar(props: CommandBarProps) {
   let inputRef: HTMLInputElement;
   let contentRef: HTMLDivElement;
-  // const t = useTranslation(props.lang);
   const [command, setCommand] = createSignal<string>();
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we check for undefined in the ternary

--- a/src/components/command-bar/CommandBar.tsx
+++ b/src/components/command-bar/CommandBar.tsx
@@ -4,19 +4,30 @@ import { createFetch, withAbort, withCatchAll, fetchRequest } from "@solid-primi
 import { Show, createSignal, onCleanup, createEffect, createMemo } from "solid-js";
 import { commandBarState, hideCommandBar, showCommandBar } from "@/stores/command-bar.store";
 import { getEntryURL } from "@/utils/content/client";
-import { useTranslation, type Language } from "@/utils/i18n";
 import SearchResults from "./SearchResults";
 import type { CommandBarItem, CommandBarLinkItem } from "./command-bar-item.type";
 import { createComboboxStore } from "@/stores/combobox";
-import { gTag } from "@/utils/analytics";
 import { withMapper } from "./withMapper";
 
 const fetcher = fetchRequest();
 
-export default function CommandBar(props: { lang: Language }) {
-  let inputRef: HTMLInputElement | undefined;
-  let contentRef: HTMLDivElement | undefined;
-  const t = useTranslation(props.lang);
+type CommandBarProps = {
+  localeStrings: {
+    close: string;
+    search: string;
+    searchPlaceholder: string;
+    error: string;
+    cancel: string;
+    loading: string;
+    empty: string;
+    searchPoweredBy: string;
+  };
+};
+
+export default function CommandBar(props: CommandBarProps) {
+  let inputRef: HTMLInputElement;
+  let contentRef: HTMLDivElement;
+  // const t = useTranslation(props.lang);
   const [command, setCommand] = createSignal<string>();
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we check for undefined in the ternary
@@ -27,8 +38,6 @@ export default function CommandBar(props: { lang: Language }) {
     withAbort(),
     withMapper(mapSearchResponse),
   ]);
-
-  createEffect(() => gTag("event", "search", { search_term: command() }));
 
   const comboboxStore = createComboboxStore<CommandBarItem>([]);
 
@@ -44,12 +53,10 @@ export default function CommandBar(props: { lang: Language }) {
   const handleOpenChange = (v: boolean) => {
     if (v) {
       showCommandBar();
-      gTag("event", "commandbar", "open");
     } else {
       if (abort) abort();
       hideCommandBar();
       setCommandDebounced();
-      gTag("event", "commandbar", "close");
     }
   };
 
@@ -81,9 +88,6 @@ export default function CommandBar(props: { lang: Language }) {
       if (href.pathname === window.location.pathname) {
         hideCommandBar();
         setCommand(undefined);
-        gTag("event", "commandbar", "refresh", href);
-      } else {
-        gTag("event", "commandbar", "link", href);
       }
     }
   };
@@ -106,8 +110,8 @@ export default function CommandBar(props: { lang: Language }) {
         <div class="fixed inset-0 z-50">
           <Dialog.Content ref={e => (contentRef = e)} onOpenAutoFocus={onOpenAutoFocus} class="contents">
             <div class="sr-only">
-              <Dialog.Title>{t("ui", "search")}</Dialog.Title>
-              <Dialog.Description>{t("ui", "commandbar.placeholder.search")}</Dialog.Description>
+              <Dialog.Title>{props.localeStrings.search}</Dialog.Title>
+              <Dialog.Description>{props.localeStrings.searchPlaceholder}</Dialog.Description>
             </div>
             <div class="p-4 md:translate-y-32">
               <div class="container mx-auto h-fit w-full max-w-4xl rounded border-slate-100 bg-blue-50 p-2 shadow-xl dark:border-gray-900 dark:bg-gray-950 md:p-4">
@@ -131,8 +135,8 @@ export default function CommandBar(props: { lang: Language }) {
                   <input
                     autofocus
                     ref={r => (inputRef = r)}
-                    aria-label={t("ui", "search")}
-                    placeholder={t("ui", "commandbar.placeholder.search")}
+                    aria-label={props.localeStrings.search}
+                    placeholder={props.localeStrings.searchPlaceholder}
                     aria-activeDescendant={comboboxStore.getSelectedItem()?.id}
                     enterkeyhint="go"
                     spellcheck={false}
@@ -149,7 +153,7 @@ export default function CommandBar(props: { lang: Language }) {
                     onInput={onCommandChange}
                   />
                   <Dialog.CloseButton class="inline-block bg-blue-100 p-2 px-3 font-light dark:bg-gray-800 md:hidden">
-                    {t("ui", "cancel")}
+                    {props.localeStrings.cancel}
                   </Dialog.CloseButton>
                 </div>
                 <Show when={command()}>
@@ -157,15 +161,15 @@ export default function CommandBar(props: { lang: Language }) {
                     selected={comboboxStore.getSelectedItem}
                     isLoading={results.loading}
                     isError={!!results.error}
-                    errorMessage={t("ui", "commandbar.error")}
-                    loadingMessage={t("ui", "commandbar.loading")}
-                    emptyMessage={t("ui", "commandbar.empty")}
+                    errorMessage={props.localeStrings.error}
+                    loadingMessage={props.localeStrings.loading}
+                    emptyMessage={props.localeStrings.empty}
                     items={results() ?? []}
                   />
                 </Show>
                 <Show when={command()}>
                   <div class="flex items-center gap-2 p-4 text-sm text-slate-400 dark:text-slate-50">
-                    <span>{t("messages", "serch_powered_by")}</span>
+                    <span>{props.localeStrings.searchPoweredBy}</span>
                     <svg viewBox="0 0 500 500.34" aria-label="Algolia" class="w-4 text-[#003dff] dark:text-slate-50">
                       <path
                         d="M250 0C113.38 0 2 110.16.03 246.32c-2 138.29 110.19 252.87 248.49 253.67 42.71.25 83.85-10.2 120.38-30.05 3.56-1.93 4.11-6.83 1.08-9.52l-23.39-20.74c-4.75-4.22-11.52-5.41-17.37-2.92-25.5 10.85-53.21 16.39-81.76 16.04-111.75-1.37-202.04-94.35-200.26-206.1C48.96 136.37 139.26 47.15 250 47.15h202.83v360.53L337.75 305.43c-3.72-3.31-9.43-2.66-12.43 1.31-18.47 24.46-48.56 39.67-81.98 37.36-46.36-3.2-83.92-40.52-87.4-86.86-4.15-55.28 39.65-101.58 94.07-101.58 49.21 0 89.74 37.88 93.97 86.01.38 4.28 2.31 8.28 5.53 11.13l29.97 26.57c3.4 3.01 8.8 1.17 9.63-3.3 2.16-11.55 2.92-23.6 2.07-35.95-4.83-70.39-61.84-127.01-132.26-131.35-80.73-4.98-148.23 58.18-150.37 137.35-2.09 77.15 61.12 143.66 138.28 145.36 32.21.71 62.07-9.42 86.2-26.97L483.39 497.8c6.45 5.71 16.62 1.14 16.62-7.48V9.49C500 4.25 495.75 0 490.51 0H250z"
@@ -178,7 +182,7 @@ export default function CommandBar(props: { lang: Language }) {
             </div>
             <Dialog.CloseButton
               class="fixed right-8 top-6 hidden rounded-full bg-slate-950/30 p-2 text-slate-50 md:block"
-              aria-label={t("ui", "close")}
+              aria-label={props.localeStrings.close}
             >
               <svg
                 class="w-6"

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -1,11 +1,25 @@
 import { For, Show, createSignal, createMemo } from "solid-js";
 import { createStore } from "solid-js/store";
-import { useTranslation, type Language } from "@/utils/i18n";
+import type { Language } from "@/utils/i18n";
 import { contactFormScheme, validReasons, ContactFormError, type ContactForm } from "@/utils/contactForm";
 
 interface Props {
   lang: Language;
   action: string;
+  localeString: {
+    defaultReason: string;
+    disclaimer: string;
+    email: string;
+    error: string;
+    message: string;
+    messagePlaceholder: string;
+    name: string;
+    reason: string;
+    reasonOptions: Record<(typeof validReasons)[number], string>;
+    submit: string;
+    submitting: string;
+    success: string;
+  };
 }
 
 const baseFormControlClasses =
@@ -40,7 +54,7 @@ const emptyForm = {
 };
 
 export default function ContactForm(props: Props) {
-  const t = useTranslation(props.lang);
+  // const t = useTranslation(props.lang);
   const [showSuccess, setShowSuccess] = createSignal(false);
   const [formState, setFormState] = createStore<FormState>({
     errors: emptyErrors,
@@ -87,6 +101,8 @@ export default function ContactForm(props: Props) {
       setShowSuccess(true);
     } catch (e) {
       if (e instanceof ContactFormError) {
+        const useTranslation = await import("@/utils/i18n").then(({ useTranslation }) => useTranslation);
+        const t = useTranslation(props.lang);
         setFormState({ errors: e.getMessages(t) });
         if (e.errors.nationality) {
           resetForm(form);
@@ -107,7 +123,7 @@ export default function ContactForm(props: Props) {
         <div class="flex-1">
           <div class="mb-4 flex items-center gap-3">
             <label for="name" class="block font-semibold">
-              {t("forms", "name")}
+              {props.localeString.name}
             </label>
             <span id="name-error" class={errorFormMessageClasses}>
               {formState.errors.name && formState.errors.name}
@@ -132,7 +148,7 @@ export default function ContactForm(props: Props) {
         <div class="flex-1">
           <div class="mb-4 flex items-center gap-3">
             <label for="email" class="block font-semibold">
-              {t("forms", "email")}
+              {props.localeString.email}
             </label>
             <span id="email-error" class={errorFormMessageClasses}>
               {formState.errors.email && formState.errors.email}
@@ -158,7 +174,7 @@ export default function ContactForm(props: Props) {
       <div class="block">
         <div class="mb-4 flex items-center gap-3">
           <label for="reason" class="block font-semibold">
-            {t("forms", "reason")}
+            {props.localeString.reason}
           </label>
           <span id="reason-error" class={errorFormMessageClasses}>
             {formState.errors.reason && formState.errors.reason}
@@ -183,15 +199,17 @@ export default function ContactForm(props: Props) {
           }}
         >
           <option value="" disabled selected>
-            {t("forms", "reason.default")}
+            {props.localeString.defaultReason}
           </option>
-          <For each={validReasons}>{reason => <option value={reason}>{t("forms", `reason.${reason}`)}</option>}</For>
+          <For each={validReasons}>
+            {reason => <option value={reason}>{props.localeString.reasonOptions[reason]}</option>}
+          </For>
         </select>
       </div>
       <div class="block">
         <div class="mb-4 flex items-center gap-3">
           <label for="message" class="block font-semibold">
-            {t("forms", "message")}
+            {props.localeString.message}
           </label>
           <span id="message-error" class={errorFormMessageClasses}>
             {formState.errors.message && formState.errors.message}
@@ -210,17 +228,17 @@ export default function ContactForm(props: Props) {
             [errorFormControlClasses]: !!formState.errors.message,
           }}
           rows="8"
-          placeholder={t("forms", "message.placeholder")}
+          placeholder={props.localeString.messagePlaceholder}
         ></textarea>
       </div>
-      <p class="!mt-2 pl-2 text-xs">{t("forms", "disclaimer")}</p>
+      <p class="!mt-2 pl-2 text-xs">{props.localeString.disclaimer}</p>
       <div class="flex items-center gap-4">
         <button
           disabled={formState.submitting}
           type="submit"
           class="block rounded-md bg-blue-200 px-6 py-3 font-semibold shadow transition-colors focus:bg-blue-200/80 focus:outline-none focus:ring focus:ring-blue-200 enabled:hover:bg-blue-200/80 enabled:active:bg-blue-300/50 disabled:cursor-not-allowed disabled:opacity-80 dark:bg-slate-800 dark:text-white dark:focus:bg-slate-700 dark:focus:ring-slate-600 enabled:dark:hover:bg-slate-800/80 enabled:dark:active:bg-slate-700"
         >
-          {t("forms", formState.submitting ? "submitting" : "submit")}
+          {formState.submitting ? props.localeString.submitting : props.localeString.submit}
         </button>
         <div
           aria-live="polite"
@@ -231,7 +249,7 @@ export default function ContactForm(props: Props) {
           }}
         >
           <Show when={showFormMessage()}>
-            <p>{t("forms", formMessageKey())}</p>
+            <p>{formMessageKey().includes("success") ? props.localeString.success : props.localeString.error}</p>
           </Show>
         </div>
       </div>

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -54,7 +54,6 @@ const emptyForm = {
 };
 
 export default function ContactForm(props: Props) {
-  // const t = useTranslation(props.lang);
   const [showSuccess, setShowSuccess] = createSignal(false);
   const [formState, setFormState] = createStore<FormState>({
     errors: emptyErrors,
@@ -102,7 +101,7 @@ export default function ContactForm(props: Props) {
     } catch (e) {
       if (e instanceof ContactFormError) {
         const useTranslation = await import("@/utils/i18n").then(({ useTranslation }) => useTranslation);
-        const t = useTranslation(props.lang);
+        const t = await useTranslation(props.lang);
         setFormState({ errors: e.getMessages(t) });
         if (e.errors.nationality) {
           resetForm(form);

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -3,7 +3,7 @@ import TwitterLogo from "@/components/logos/Twitter.astro";
 import GitHubLogo from "@/components/logos/GitHub.astro";
 import LinkedInLogo from "@/components/logos/LinkedIn.astro";
 import RSSFeedLogo from "@/components/logos/RSSFeed.astro";
-import { useTranslation, type Language, getLocalizedPage } from "@/utils/i18n";
+import { useTranslation, type Language, getLocalizedPage, getLanguageName } from "@/utils/i18n";
 
 import ThemeSelector from "@/components/user-settings/ThemeSelector";
 import LanguageSelector from "@/components/user-settings/LanguageSelector";
@@ -31,20 +31,43 @@ const t = useTranslation(lang);
 const currentLanguage: EntryTranslationReference = { slug: Astro.url.toString(), lang };
 const translations = propTranslations
   .concat(currentLanguage)
-  .filter(({ lang: translationLang }) => translationLang !== ("x-default" as unknown as Language));
+  .filter(({ lang: translationLang }) => translationLang !== ("x-default" as unknown as Language))
+  .map(({ lang, ...rest }) => ({ ...rest, lang, name: getLanguageName(lang) }));
+
+const copyText = {
+  copyright: t("ui", "copyright"),
+  themeSelector: {
+    selectTheme: t("ui", "theme.select"),
+    themes: {
+      light: t("ui", "theme.light"),
+      dark: t("ui", "theme.dark"),
+      auto: t("ui", "theme.auto"),
+    },
+  },
+  languageSelector: {
+    selectLanguage: t("ui", "translation.select"),
+    unavailable: t("ui", "translation.not_available"),
+  },
+};
 ---
 
 <footer
   class="container mx-auto border-t border-slate-200/50 px-2 py-6 text-center dark:border-slate-700/50 sm:px-6 sm:text-left"
 >
   <div class="flex items-center justify-center gap-4 pb-6 sm:justify-between">
-    <ThemeSelector lang={lang} client:visible />
-    <LanguageSelector lang={lang} options={translations} value={currentLanguage} client:visible />
+    <ThemeSelector localeStrings={copyText.themeSelector} client:visible />
+    <LanguageSelector
+      localeStrings={copyText.languageSelector}
+      lang={lang}
+      options={translations}
+      value={currentLanguage}
+      client:visible
+    />
   </div>
   <div class="text-xs">
     <div class="sm:flex sm:items-center sm:justify-between">
       <p class="hidden sm:block">
-        {t("ui", "copyright")} ©️{year} - <strong class="font-semibold">Misael Taveras</strong>
+        {copyText.copyright} ©️{year} - <strong class="font-semibold">Misael Taveras</strong>
       </p>
       <div class="flex items-center justify-center gap-4">
         {

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -26,7 +26,7 @@ const social = [
 /* eslint-enable @typescript-eslint/no-unsafe-assignment */
 
 const year = new Date().getFullYear();
-const t = useTranslation(lang);
+const t = await useTranslation(lang);
 
 const currentLanguage: EntryTranslationReference = { slug: Astro.url.toString(), lang };
 const translations = propTranslations

--- a/src/components/layout/GoToTop.astro
+++ b/src/components/layout/GoToTop.astro
@@ -5,7 +5,7 @@ interface Props {
   lang: Language;
 }
 
-const t = useTranslation(Astro.props.lang);
+const t = await useTranslation(Astro.props.lang);
 const label = t("ui", "go_top");
 ---
 

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -9,7 +9,7 @@ interface Props {
 const basePath = Astro.url.pathname;
 
 const lang = Astro.props.lang ?? DEFAULT_LOCALE;
-const t = useTranslation(lang);
+const t = await useTranslation(lang);
 ---
 
 <header id="header" class="top-0 w-full bg-white shadow-lg transition-transform dark:bg-slate-950/80">

--- a/src/components/layout/MinimalHeader.astro
+++ b/src/components/layout/MinimalHeader.astro
@@ -6,7 +6,7 @@ interface Props {
 }
 
 const lang = Astro.props.lang ?? DEFAULT_LOCALE;
-const t = useTranslation(lang);
+const t = await useTranslation(lang);
 ---
 
 <header id="header" class="relative top-0 w-full bg-transparent">

--- a/src/components/layout/Nav.astro
+++ b/src/components/layout/Nav.astro
@@ -19,7 +19,7 @@ function isIgnoredPage(n: PageName): n is ValidPageName {
 
 const validPages: ValidPageName[] = PAGE_NAMES.filter(isIgnoredPage);
 const localizePage = (page: PageName) => getLocalizedPage(lang, page);
-const t = useTranslation(lang);
+const t = await useTranslation(lang);
 const pages = validPages.map(name => ({
   name: t("navigation", name),
   path: localizePage(name),

--- a/src/components/user-settings/LanguageSelector.tsx
+++ b/src/components/user-settings/LanguageSelector.tsx
@@ -1,20 +1,11 @@
 import { For, createMemo, createSignal } from "solid-js";
-import { type EntryTranslationReference } from "@/utils/content";
-import { useTranslation, type Language, getLanguageName } from "@/utils/i18n";
+import type { LanguageSelectorProps } from "./interfaces";
 
-interface Props {
-  lang: Language;
-  options: EntryTranslationReference[];
-  value: EntryTranslationReference;
-}
-
-export default function LanguageSelector(props: Props) {
-  const t = useTranslation(props.lang);
-
+export default function LanguageSelector(props: LanguageSelectorProps) {
   // We do not need to set the value, because we navigate to translated page
   const [value] = createSignal(props.value);
   const shouldDisable = createMemo(() => props.options.length <= 1);
-
+  const title = shouldDisable() ? props.localeStrings.unavailable : props.localeStrings.selectLanguage;
   const setValue = (e: Event) => (window.location.href = (e.currentTarget as HTMLSelectElement).value);
 
   return (
@@ -22,22 +13,20 @@ export default function LanguageSelector(props: Props) {
       for="lang-selector"
       class="relative rounded-md bg-white shadow ring-1 ring-blue-50 focus-within:outline-none focus-within:ring dark:bg-gray-950 dark:ring-gray-900"
     >
-      <span class="sr-only">
-        {shouldDisable() ? t("ui", "translation.not_available") : t("ui", "translation.select")}
-      </span>
+      <span class="sr-only">{title}</span>
       <select
         name="lang-selector"
         id="lang-selector"
         onChange={setValue}
-        title={shouldDisable() ? t("ui", "translation.not_available") : t("ui", "translation.select")}
+        title={title}
         disabled={shouldDisable()}
         value={value().slug}
         class="w-full appearance-none bg-transparent px-4 py-2 pr-10 focus:outline-none disabled:opacity-50 aria-expanded:ring-2"
       >
         <For each={props.options}>
           {option => (
-            <option value={option.slug} disabled={option.lang === props.lang} selected={value() === option}>
-              {getLanguageName(option.lang)}
+            <option value={option.slug} disabled={option.lang === props.lang} selected={value().lang === option.lang}>
+              {option.name}
             </option>
           )}
         </For>

--- a/src/components/user-settings/ThemeSelector.tsx
+++ b/src/components/user-settings/ThemeSelector.tsx
@@ -1,17 +1,10 @@
 import { For, Match, Switch, createSignal, onCleanup, onMount } from "solid-js";
-import { useTranslation, type Language } from "@/utils/i18n";
+import type { ThemeOption, ThemeSelectorProps } from "./interfaces";
 
-interface Props {
-  lang: Language;
-}
+const options: ThemeOption[] = ["dark", "light", "auto"];
 
-const options: ThemeOption[] = ["theme.dark", "theme.light", "theme.auto"];
-type ThemeOption = "theme.dark" | "theme.light" | "theme.auto";
-
-export default function LanguageSelector(props: Props) {
-  const t = useTranslation(props.lang);
-
-  const [value, setValue] = createSignal<ThemeOption>("theme.auto");
+export default function LanguageSelector(props: ThemeSelectorProps) {
+  const [value, setValue] = createSignal<ThemeOption>("auto");
 
   onMount(() => {
     setValue(toThemeOption(localStorage.getItem("theme") ?? "auto"));
@@ -22,8 +15,7 @@ export default function LanguageSelector(props: Props) {
   });
 
   const setTheme = (e: Event) => {
-    const value = (e.currentTarget as HTMLSelectElement).value as ThemeOption;
-    const theme = themeOptionToString(value);
+    const theme = (e.currentTarget as HTMLSelectElement).value as ThemeOption;
     localStorage.setItem("theme", theme);
     setValue(value);
 
@@ -41,7 +33,7 @@ export default function LanguageSelector(props: Props) {
       for="theme-selector"
       class="relative rounded-md bg-white shadow ring-1 ring-blue-50 focus-within:outline-none focus-within:ring dark:bg-gray-950 dark:ring-gray-900"
     >
-      <span class="sr-only">{t("ui", "theme.select")}</span>
+      <span class="sr-only">{props.localeStrings.selectTheme}</span>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         aria-hidden={true}
@@ -50,17 +42,17 @@ export default function LanguageSelector(props: Props) {
         class="pointer-events-none absolute left-4 top-1/2 w-4 -translate-y-1/2"
       >
         <Switch>
-          <Match when={value() === "theme.dark"}>
+          <Match when={value() === "dark"}>
             <path
               fill-rule="evenodd"
               d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z"
               clip-rule="evenodd"
             />
           </Match>
-          <Match when={value() === "theme.light"}>
+          <Match when={value() === "light"}>
             <path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z" />
           </Match>
-          <Match when={value() === "theme.auto"}>
+          <Match when={value() === "auto"}>
             <path
               fill-rule="evenodd"
               d="M2.25 5.25a3 3 0 013-3h13.5a3 3 0 013 3V15a3 3 0 01-3 3h-3v.257c0 .597.237 1.17.659 1.591l.621.622a.75.75 0 01-.53 1.28h-9a.75.75 0 01-.53-1.28l.621-.622a2.25 2.25 0 00.659-1.59V18h-3a3 3 0 01-3-3V5.25zm1.5 0v7.5a1.5 1.5 0 001.5 1.5h13.5a1.5 1.5 0 001.5-1.5v-7.5a1.5 1.5 0 00-1.5-1.5H5.25a1.5 1.5 0 00-1.5 1.5z"
@@ -78,7 +70,7 @@ export default function LanguageSelector(props: Props) {
         <For each={options}>
           {option => (
             <option value={option} selected={value() === option}>
-              {t("ui", option)}
+              {props.localeStrings.themes[option]}
             </option>
           )}
         </For>
@@ -88,9 +80,7 @@ export default function LanguageSelector(props: Props) {
 }
 
 const toThemeOption = (theme: string): ThemeOption =>
-  theme === "light" || theme === "dark" || theme === "auto" ? `theme.${theme}` : "theme.auto";
-
-const themeOptionToString = (theme: ThemeOption): string => theme.split(".")[1];
+  theme === "light" || theme === "dark" || theme === "auto" ? theme : "auto";
 
 const changeAutoTheme = (e: MediaQueryListEvent) =>
   e.matches ? document.documentElement.classList.add("dark") : document.documentElement.classList.remove("dark");

--- a/src/components/user-settings/interfaces.tsx
+++ b/src/components/user-settings/interfaces.tsx
@@ -1,0 +1,17 @@
+import type { EntryTranslationReference } from "@/utils/content";
+import type { Language } from "@/utils/i18n";
+
+export type ThemeOption = "dark" | "light" | "auto";
+export type ThemeSelectorProps = {
+  localeStrings: {
+    selectTheme: string;
+    themes: Record<ThemeOption, string>;
+  };
+};
+
+export type LanguageSelectorProps = {
+  lang: Language;
+  options: Array<EntryTranslationReference & { name: string }>;
+  value: EntryTranslationReference;
+  localeStrings: { selectLanguage: string; unavailable: string };
+};

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -61,7 +61,7 @@
     "reading_translation_archive": "This {{collection_name}} is originally written in {{original_language}}. To see all the entries, visit the ",
     "incomplete_translation_disclaimer": "This translation may be incomplete. To see the original version, visit the ",
     "cv_is_available_in": "My resume is available to ",
-    "serch_powered_by": "Search powered by"
+    "search_powered_by": "Search powered by"
   },
   "page_descriptions": {
     "blog": "Find articles about web development, technology, programming, design and more.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -61,7 +61,7 @@
     "reading_translation_archive": "[NOTE]: esta KEY no se usa en español, porque es el lenguaje original",
     "incomplete_translation_disclaimer": "[NOTE]: esta KEY no se usa en español, porque es el lenguaje original",
     "cv_is_available_in": "Mi cv (en inglés) está disponible para",
-    "serch_powered_by": "Resultados gracias a "
+    "search_powered_by": "Resultados gracias a "
   },
   "page_descriptions": {
     "blog": "Encuentra artículos sobre desarrollo web, tecnología, programación, diseño y más.",

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,7 +1,4 @@
-import Spanish from "./es.json";
-import English from "./en.json";
-
-type BaseLocale = typeof Spanish;
+export type BaseLocale = typeof import("./es.json");
 
 export const LANGUAGES = ["es", "en"] as const;
 export type Language = (typeof LANGUAGES)[number];
@@ -10,19 +7,13 @@ export const DEFAULT_LOCALE = "es" satisfies Language;
 
 export type LocaleSet = Record<Language, BaseLocale>;
 
-export const locales = {
-  es: Spanish,
-  en: English,
-} as const satisfies LocaleSet;
-
 export const PAGE_NAMES = ["home", "about", "blog", "contact", "feed"] as const;
 export type PageName = (typeof PAGE_NAMES)[number];
 type PageURL = Record<PageName, Readonly<string>>;
 
 export const PAGE_URLS = {
-  // This might look silly now, but maybe in the future the keys and values will be different.
-  // For example, if we want to have a "promo23" page, we can have it as a key, but the URL
-  // can be "promo-2023" or something like that.
+  // ~~This might look silly now, but maybe in the future the keys and values will be different.~~
+  // We now have feed->rss.xml, so it's not silly anymore.
   home: "",
   blog: "blog",
   about: "about",

--- a/src/layouts/Basic.astro
+++ b/src/layouts/Basic.astro
@@ -43,7 +43,7 @@ const copyText = {
     error: t("ui", "commandbar.error"),
     loading: t("ui", "commandbar.loading"),
     empty: t("ui", "commandbar.empty"),
-    searchPoweredBy: t("messages", "serch_powered_by"),
+    searchPoweredBy: t("messages", "search_powered_by"),
   },
 };
 ---

--- a/src/layouts/Basic.astro
+++ b/src/layouts/Basic.astro
@@ -1,5 +1,5 @@
 ---
-import { DEFAULT_LOCALE } from "@/utils/i18n";
+import { DEFAULT_LOCALE, useTranslation } from "@/utils/i18n";
 import CommandBar from "@/components/command-bar/CommandBar";
 import OpenGraphTags from "@/components/layout/OpenGraphTags.astro";
 import { slugToCanonical } from "@/utils/content";
@@ -31,6 +31,21 @@ const image = propsImage ?? slugToCanonical(`/default-og-${lang}.png`);
 const manifest = lang === "es" ? "/manifest.json" : `/manifest-${lang}.json`;
 const { origin } = Astro.url;
 const { VERCEL_GIT_COMMIT_SHA: COMMIT_SHA } = getEnv();
+
+const t = useTranslation(lang);
+
+const copyText = {
+  commandBar: {
+    close: t("ui", "close"),
+    search: t("ui", "search"),
+    cancel: t("ui", "cancel"),
+    searchPlaceholder: t("ui", "commandbar.placeholder.search"),
+    error: t("ui", "commandbar.error"),
+    loading: t("ui", "commandbar.loading"),
+    empty: t("ui", "commandbar.empty"),
+    searchPoweredBy: t("messages", "serch_powered_by"),
+  },
+};
 ---
 
 <!doctype html>
@@ -76,7 +91,7 @@ const { VERCEL_GIT_COMMIT_SHA: COMMIT_SHA } = getEnv();
   >
     <slot />
     <Footer lang={lang} translations={translations} />
-    <CommandBar lang={lang} client:idle />
+    <CommandBar localeStrings={copyText.commandBar} client:idle />
     <slot name="post-footer" />
     <script src="./keyboard-shortcuts.ts"></script>
     <script is:inline>

--- a/src/layouts/Basic.astro
+++ b/src/layouts/Basic.astro
@@ -32,7 +32,7 @@ const manifest = lang === "es" ? "/manifest.json" : `/manifest-${lang}.json`;
 const { origin } = Astro.url;
 const { VERCEL_GIT_COMMIT_SHA: COMMIT_SHA } = getEnv();
 
-const t = useTranslation(lang);
+const t = await useTranslation(lang);
 
 const copyText = {
   commandBar: {

--- a/src/layouts/pages/About.astro
+++ b/src/layouts/pages/About.astro
@@ -32,7 +32,7 @@ const translations = LANGUAGES.filter(l => l !== lang).map(language => ({
 }));
 
 const canonical = slugToCanonical(getLocalizedPage(lang, PAGE), origin);
-const t = useTranslation(lang);
+const t = await useTranslation(lang);
 
 const copyText = {
   layout: { description: t("page_descriptions", PAGE), title: t("navigation", PAGE) },

--- a/src/layouts/pages/About.astro
+++ b/src/layouts/pages/About.astro
@@ -33,22 +33,30 @@ const translations = LANGUAGES.filter(l => l !== lang).map(language => ({
 
 const canonical = slugToCanonical(getLocalizedPage(lang, PAGE), origin);
 const t = useTranslation(lang);
+
+const copyText = {
+  layout: { description: t("page_descriptions", PAGE), title: t("navigation", PAGE) },
+  body: {
+    csvAvailable: t("messages", "cv_is_available_in"),
+    downloadHere: t("ui", "download_here").toLocaleLowerCase(),
+  },
+};
 ---
 
 <Layout
   lang={lang}
   canonical={canonical}
-  description={t("page_descriptions", PAGE)}
-  title={t("navigation", PAGE)}
+  description={copyText.layout.description}
+  title={copyText.layout.title}
   translations={translations}
 >
   <main>
     <PageBanner class="bg-blue-100 dark:bg-gray-950">
-      {t("messages", "cv_is_available_in")}
+      {copyText.body.csvAvailable}
       {" "}<a
         href="/taverasmisael-frontend-engineer-resume.pdf"
         download="Misael-Taveras__frontend-engineer--resume.pdf"
-        class="underline">{t("ui", "download_here").toLocaleLowerCase()}</a
+        class="underline">{copyText.body.downloadHere}</a
       >.
     </PageBanner>
     <div class="container mx-auto w-full">

--- a/src/layouts/pages/Contact.astro
+++ b/src/layouts/pages/Contact.astro
@@ -39,6 +39,29 @@ const translations = LANGUAGES.filter(l => l !== lang).map(language => ({
 
 const canonical = slugToCanonical(getLocalizedPage(lang, PAGE), origin);
 const t = useTranslation(lang);
+
+const copyText = {
+  form: {
+    defaultReason: t("forms", "reason.default"),
+    disclaimer: t("forms", "disclaimer"),
+    email: t("forms", "email"),
+    error: t("forms", "contact.error"),
+    message: t("forms", "message"),
+    messagePlaceholder: t("forms", "message.placeholder"),
+    name: t("forms", "name"),
+    reason: t("forms", "reason"),
+    reasonOptions: {
+      hello: t("forms", "reason.hello"),
+      help: t("forms", "reason.help"),
+      other: t("forms", "reason.other"),
+      question: t("forms", "reason.question"),
+      work: t("forms", "reason.work"),
+    },
+    submit: t("forms", "submit"),
+    submitting: t("forms", "submitting"),
+    success: t("forms", "contact.success"),
+  },
+};
 ---
 
 <Layout
@@ -70,7 +93,7 @@ const t = useTranslation(lang);
             </div>
           </FullWidthBlock>
           <div class="px-6 py-4 sm:px-8 lg:mt-20 lg:py-12 xl:mt-0 xl:px-24">
-            <ContactForm client:idle action="/api/contact" lang={lang} />
+            <ContactForm client:idle action="/api/contact" localeString={copyText.form} lang={lang} />
           </div>
         </div>
       </div>

--- a/src/layouts/pages/Contact.astro
+++ b/src/layouts/pages/Contact.astro
@@ -38,7 +38,7 @@ const translations = LANGUAGES.filter(l => l !== lang).map(language => ({
 }));
 
 const canonical = slugToCanonical(getLocalizedPage(lang, PAGE), origin);
-const t = useTranslation(lang);
+const t = await useTranslation(lang);
 
 const copyText = {
   form: {

--- a/src/layouts/pages/Home.astro
+++ b/src/layouts/pages/Home.astro
@@ -31,7 +31,7 @@ const translations = LANGUAGES.filter(l => l !== lang)
     },
   ]);
 
-const t = useTranslation(lang);
+const t = await useTranslation(lang);
 ---
 
 <Layout

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -18,7 +18,7 @@ const luckyPost = allPosts[Math.floor(Math.random() * allPosts.length)] as BlogE
 const homeURL = getLocalizedPage(lang, "home");
 const luckyURL = luckyPost ? getEntryURL("blog", luckyPost.entry.slug) : getLocalizedPage(lang, "blog");
 
-const t = useTranslation(lang);
+const t = await useTranslation(lang);
 const canonical = slugToCanonical("/404");
 ---
 

--- a/src/pages/[lang]/blog/[...entrySlug]/image.png.ts
+++ b/src/pages/[lang]/blog/[...entrySlug]/image.png.ts
@@ -15,15 +15,15 @@ export async function GET({ params }: { params: Record<string, string> }) {
   try {
     console.time("og-image");
     const post = await getBlogEntry(Object.values(params).join("/"));
-
     if (!post) return new Response("NOT FOUND", { status: 404 });
+    const t = await useTranslation(post.meta.lang);
     const svg = await generateOGImage({
       title: post.meta.title,
       description: post.meta.description,
       image: "https://raw.githubusercontent.com/taverasmisael/taverasmisael.com/main/public/og-image-bg.png",
       width: WIDTH,
       height: HEIGHT,
-      writtenTag: useTranslation(post.meta.lang)("ui", "written_by"),
+      writtenTag: t("ui", "written_by"),
     });
 
     console.timeEnd("og-image");

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -32,7 +32,7 @@ const translations = LANGUAGES.filter(l => l !== lang).map(l => ({
   lang: l,
   isOriginal: l === DEFAULT_LOCALE,
 }));
-const t = useTranslation(lang);
+const t = await useTranslation(lang);
 ---
 
 <Layout

--- a/src/pages/[lang]/rss.xml.ts
+++ b/src/pages/[lang]/rss.xml.ts
@@ -10,7 +10,7 @@ export async function GET(context: APIContext) {
   if (!isSupportedLang(lang)) {
     return context.redirect("/rss.xml");
   }
-  const t = useTranslation(lang);
+  const t = await useTranslation(lang);
   const site = (context.site ?? "").toString();
 
   return generateRSSFeed({

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -12,7 +12,7 @@ export async function POST({ request }: { request: Request }) {
       const parsedRequest = contactFormScheme.safeParse(requestData);
       if (parsedRequest.success) {
         const { data } = parsedRequest;
-        const t = useTranslation(data.lang);
+        const t = await useTranslation(data.lang);
         const body = new URLSearchParams({
           to: CONTACT_EMAIL,
           subject: `${data.name} wants you for "${t("forms", `reason.${data.reason}`)}"`,

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -2,9 +2,8 @@ import type { APIContext } from "astro";
 import { generateRSSFeed } from "@/utils/rss";
 import { useTranslation } from "@/utils/i18n";
 
-const t = useTranslation("es");
-
 export async function GET(context: APIContext) {
+  const t = await useTranslation("es");
   return generateRSSFeed({
     site: (context.site ?? "").toString(),
     description: t("page_descriptions", "blog"),

--- a/src/utils/contactForm.ts
+++ b/src/utils/contactForm.ts
@@ -1,6 +1,6 @@
 import { map } from "rambda";
 import { z, type ZodError, type ZodIssue } from "zod";
-import { LANGUAGES, type Language, type UseTranslation } from "@/utils/i18n";
+import type { Language, UseTranslation } from "@/utils/i18n";
 
 export const validReasons = ["hello", "question", "help", "work", "other"] as const;
 
@@ -9,7 +9,7 @@ export const contactFormScheme = z.object({
   email: z.string().email(),
   reason: z.enum(validReasons),
   message: z.string().min(10).max(500),
-  lang: z.enum(LANGUAGES),
+  lang: z.enum(["en", "es"]),
   nationality: z.undefined(),
 });
 

--- a/src/utils/content/client.ts
+++ b/src/utils/content/client.ts
@@ -1,4 +1,4 @@
-import { type Language } from "@/utils/i18n";
+import type { Language } from "@/utils/i18n";
 import { type CollectionKey, Collections } from "./types";
 
 // We know SITE is defined because we triple check on build time.

--- a/src/utils/content/types.ts
+++ b/src/utils/content/types.ts
@@ -1,5 +1,5 @@
 import { type CollectionEntry, getCollection } from "astro:content";
-import { type Language } from "@/utils/i18n";
+import type { Language } from "@/utils/i18n";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CollectionNames = typeof getCollection extends (name: infer T, ...args: any[]) => any ? T : never;

--- a/src/utils/rss.ts
+++ b/src/utils/rss.ts
@@ -13,16 +13,14 @@ export function blogEntryToRSSItems(entries: BlogEntry[]): RSSOptions["items"] {
   }));
 }
 
-export function getRSSCustomData(lang: Language) {
-  const t = useTranslation(lang);
-
+export function getRSSCustomData(lang: Language, copyright: string) {
   return `
     <language>${lang}</language>
     <ttl>60</ttl>
     <category>Web Development</category>
     <category>Software Development</category>
     <category>Programming</category>
-    <copyright>${t("ui", "copyright")} ©️${new Date().getFullYear()} Misael Taveras</copyright>
+    <copyright>${copyright} ©️${new Date().getFullYear()} Misael Taveras</copyright>
   `;
 }
 
@@ -35,12 +33,12 @@ interface RSSConfig {
 export async function generateRSSFeed({ site, description, lang }: RSSConfig) {
   const entries = await getBlogEntriesByLang(lang);
   const items = blogEntryToRSSItems(entries);
-
+  const t = await useTranslation(lang);
   return rss({
     site,
     items,
     description,
     title: "Misael Taveras Blog",
-    customData: getRSSCustomData(lang),
+    customData: getRSSCustomData(lang, t("ui", "copyright")),
   });
 }


### PR DESCRIPTION
Closes #32

All pages currently use the i18n utility module, even if their text is static. All SolidJS components also use the utility for their texts. The problem is that most of the text can be known ahead of time and statically rendered, reducing the javascript loaded on every page.

This was possible with a big refactor on all pages and components and the `useTranslation` utility function. The `useTranslation` utility had to be revamped because it loaded ALL the translations available (only 2 for now), now and thanks to the dynamic [imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) we can progressively load only the necessary ones.

So far NO page loads the translations or the utilities client side, they're baked at _build time_. The contacts page is the only one that loads the utility but dynamically to show the errors, so if the form is submitted successfully, there is no need to load, even if it's a generic submit error. I could've also put this on build time, but it was fun to implement and opened the door to refactor the useTranslation and import the translations dynamically.

### Before (on prod)

![current](https://github.com/taverasmisael/taverasmisael.com/assets/8240480/dad88277-3c42-4c5b-a93c-d1723c618760)



### After (on this PR)
![fix](https://github.com/taverasmisael/taverasmisael.com/assets/8240480/b5ae6d91-69b1-4bc6-aa30-6ff54a876be9)

